### PR TITLE
Exit Early if Google Upload Target Exists

### DIFF
--- a/run.py
+++ b/run.py
@@ -176,6 +176,18 @@ def get_icloud_path():
     return icloud_path
 
 def upload_data(service, filename, folderId, data):
+    query = f"name='{filename}' and '{folderId}' in parents and trashed=false"
+    results = service.files().list(
+        q=query,
+        spaces='drive',
+        fields='files(id, name)'
+    ).execute()
+    existing_files = results.get('files', [])
+
+    if existing_files:
+        print(f'File exists, exiting...')
+        return
+
     file_metadata = {
         'name': filename,
         'parents': [folderId]


### PR DESCRIPTION
This PR updates the logic to exit early if the file already is found and exists in google drive. The k8s will run the job as a cronjob on some interval and we can make it idempotent by making it no-op if the file exists.